### PR TITLE
Fix virtualization shift logic when list changes

### DIFF
--- a/src/svelte/Virtualizer.svelte
+++ b/src/svelte/Virtualizer.svelte
@@ -84,10 +84,39 @@
     scroller.$dispose();
   });
 
+  let prevKeys: unknown[] = data.map((d, i) => getKey(d, i));
+
   $effect.pre(() => {
-    if (data.length !== store.$getItemsLength()) {
-      store.$update(ACTION_ITEMS_LENGTH_CHANGE, [data.length, shift]);
+    const len = data.length;
+    const prevLen = prevKeys.length;
+    if (len !== prevLen) {
+      let shouldShift = shift;
+      if (shift) {
+        const diff = len - prevLen;
+        if (diff > 0) {
+          let ok = true;
+          for (let i = diff; i < len; i++) {
+            if (getKey(data[i]!, i) !== prevKeys[i - diff]) {
+              ok = false;
+              break;
+            }
+          }
+          shouldShift = ok;
+        } else {
+          const offset = -diff;
+          let ok = true;
+          for (let i = 0; i < len; i++) {
+            if (getKey(data[i]!, i) !== prevKeys[i + offset]) {
+              ok = false;
+              break;
+            }
+          }
+          shouldShift = ok;
+        }
+      }
+      store.$update(ACTION_ITEMS_LENGTH_CHANGE, [len, shouldShift]);
     }
+    prevKeys = data.map((d, i) => getKey(d, i));
   });
 
   $effect.pre(() => {

--- a/src/svelte/WindowVirtualizer.svelte
+++ b/src/svelte/WindowVirtualizer.svelte
@@ -77,10 +77,39 @@
     scroller.$dispose();
   });
 
+  let prevKeys: unknown[] = data.map((d, i) => getKey(d, i));
+
   $effect.pre(() => {
-    if (data.length !== store.$getItemsLength()) {
-      store.$update(ACTION_ITEMS_LENGTH_CHANGE, [data.length, shift]);
+    const len = data.length;
+    const prevLen = prevKeys.length;
+    if (len !== prevLen) {
+      let shouldShift = shift;
+      if (shift) {
+        const diff = len - prevLen;
+        if (diff > 0) {
+          let ok = true;
+          for (let i = diff; i < len; i++) {
+            if (getKey(data[i]!, i) !== prevKeys[i - diff]) {
+              ok = false;
+              break;
+            }
+          }
+          shouldShift = ok;
+        } else {
+          const offset = -diff;
+          let ok = true;
+          for (let i = 0; i < len; i++) {
+            if (getKey(data[i]!, i) !== prevKeys[i + offset]) {
+              ok = false;
+              break;
+            }
+          }
+          shouldShift = ok;
+        }
+      }
+      store.$update(ACTION_ITEMS_LENGTH_CHANGE, [len, shouldShift]);
     }
+    prevKeys = data.map((d, i) => getKey(d, i));
   });
 
   let prevStateVersion: StateVersion | undefined;


### PR DESCRIPTION
## Summary
- avoid shifting list when data length changed but items weren't prepended
- apply same logic for window scroller

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Cannot find package 'typescript-eslint')*
- `npm run tsc` *(fails with missing dependencies)*
- `npm run check:svelte` *(fails: svelte-check not found)*