### PR TITLE
Add reverse mode to Svelte VList

### DIFF
--- a/src/svelte/VList.svelte
+++ b/src/svelte/VList.svelte
@@ -11,6 +11,7 @@
     overscan,
     itemSize,
     shift,
+    reverse = false,
     horizontal,
     children,
     onscroll,
@@ -58,23 +59,53 @@
     width: "100%",
     height: "100%",
   });
+
+  const reverseWrapperStyle = styleToString({
+    visibility: "hidden",
+    display: "flex",
+    "flex-direction": "column",
+    "justify-content": "flex-end",
+    "min-height": "100%",
+  });
+
+  const shouldReverse = reverse && !horizontal;
+
+  let scrollRef: HTMLDivElement | undefined = $state();
 </script>
 
 <!-- 
   @component
   Virtualized list component. See {@link VListProps} and {@link VListHandle}.
 -->
-<div {...rest} style="{viewportStyle} {rest.style || ''}">
-  <Virtualizer
-    bind:this={ref}
-    {data}
-    {children}
-    {getKey}
-    {overscan}
-    {itemSize}
-    {shift}
-    {horizontal}
-    {onscroll}
-    {onscrollend}
-  />
+<div bind:this={scrollRef} {...rest} style="{viewportStyle} {rest.style || ''}">
+  {#if shouldReverse}
+    <div style={reverseWrapperStyle}>
+      <Virtualizer
+        bind:this={ref}
+        {data}
+        {children}
+        {getKey}
+        {overscan}
+        {itemSize}
+        {shift}
+        {horizontal}
+        scrollRef={scrollRef}
+        {onscroll}
+        {onscrollend}
+      />
+    </div>
+  {:else}
+    <Virtualizer
+      bind:this={ref}
+      {data}
+      {children}
+      {getKey}
+      {overscan}
+      {itemSize}
+      {shift}
+      {horizontal}
+      {onscroll}
+      {onscrollend}
+    />
+  {/if}
 </div>

--- a/src/svelte/VList.type.ts
+++ b/src/svelte/VList.type.ts
@@ -13,6 +13,7 @@ export interface VListProps<T>
       | "itemSize"
       | "shift"
       | "horizontal"
+      | "reverse"
       | "children"
       | "onscroll"
       | "onscrollend"


### PR DESCRIPTION
## Summary
- expose `reverse` prop in `VListProps`
- add reverse layout handling in `VList.svelte`

## Testing
- `npx vitest --run --silent` *(fails: EHOSTUNREACH)*
- `npm run build` *(fails: rollup not found)*