### PR TITLE
Add reverse prop for Svelte VList and chat example

### DIFF
--- a/docs/svelte/interfaces/VListProps.md
+++ b/docs/svelte/interfaces/VListProps.md
@@ -20,6 +20,16 @@ Props of [VList](../type-aliases/VList.md).
 
 ## Properties
 
+### reverse?
+
+> `optional` **reverse**: `boolean`
+
+Defined in: [src/svelte/VList.type.ts:21](https://github.com/inokawa/virtua/blob/9beb70eb109c037ab86ea839e5f119e979768d35/src/svelte/VList.type.ts#L21)
+
+If true, items are aligned to the end of the list when total size of items are smaller than viewport size. It's useful for chat like app.
+
+***
+
 ### children
 
 > **children**: `Snippet`\<\[`T`, `number`\]\>

--- a/src/svelte/VList.svelte
+++ b/src/svelte/VList.svelte
@@ -12,6 +12,7 @@
     itemSize,
     shift,
     horizontal,
+    reverse,
     children,
     onscroll,
     onscrollend,
@@ -19,6 +20,9 @@
   }: Props = $props();
 
   let ref: Virtualizer<T> = $state()!;
+  let scrollRef: HTMLDivElement | undefined = $state();
+
+  const shouldReverse = $derived(reverse && !horizontal);
 
   export const getScrollOffset = (() =>
     ref.getScrollOffset()) satisfies VListHandle["getScrollOffset"] as VListHandle["getScrollOffset"];
@@ -58,23 +62,49 @@
     width: "100%",
     height: "100%",
   });
+
+  const wrapperStyle = styleToString({
+    visibility: "hidden", // TODO replace with other optimization methods
+    display: "flex",
+    "flex-direction": "column",
+    "justify-content": "flex-end",
+    "min-height": "100%",
+  });
 </script>
 
 <!-- 
   @component
   Virtualized list component. See {@link VListProps} and {@link VListHandle}.
 -->
-<div {...rest} style="{viewportStyle} {rest.style || ''}">
-  <Virtualizer
-    bind:this={ref}
-    {data}
-    {children}
-    {getKey}
-    {overscan}
-    {itemSize}
-    {shift}
-    {horizontal}
-    {onscroll}
-    {onscrollend}
-  />
+<div bind:this={scrollRef} {...rest} style="{viewportStyle} {rest.style || ''}">
+  {#if shouldReverse}
+    <div style={wrapperStyle}>
+      <Virtualizer
+        bind:this={ref}
+        {data}
+        {children}
+        {getKey}
+        {overscan}
+        {itemSize}
+        {shift}
+        {horizontal}
+        scrollRef={scrollRef}
+        {onscroll}
+        {onscrollend}
+      />
+    </div>
+  {:else}
+    <Virtualizer
+      bind:this={ref}
+      {data}
+      {children}
+      {getKey}
+      {overscan}
+      {itemSize}
+      {shift}
+      {horizontal}
+      {onscroll}
+      {onscrollend}
+    />
+  {/if}
 </div>

--- a/src/svelte/VList.type.ts
+++ b/src/svelte/VList.type.ts
@@ -17,7 +17,12 @@ export interface VListProps<T>
       | "onscroll"
       | "onscrollend"
     >,
-    ViewportComponentAttributes {}
+    ViewportComponentAttributes {
+  /**
+   * If true, items are aligned to the end of the list when total size of items are smaller than viewport size. It's useful for chat like app.
+   */
+  reverse?: boolean;
+}
 
 /**
  * Methods of {@link VList}.

--- a/stories/svelte/advanced/Chat.stories.svelte
+++ b/stories/svelte/advanced/Chat.stories.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+  import { VList } from "../../../src/svelte";
+  import { onMount, afterUpdate } from "svelte";
+  import { faker } from "@faker-js/faker";
+
+  type Data = { id: number; value: string; me: boolean };
+
+  let id = 0;
+  const createItem = (
+    { value = faker.lorem.paragraphs(1), me = false }: { value?: string; me?: boolean } = {}
+  ): Data => ({ id: id++, value, me });
+
+  let ref: VList<Data> = $state();
+  let items = $state(Array.from({ length: 100 }, () => createItem()));
+  let value = $state("Hello world!");
+  let isPrepend = false;
+  let shouldStickToBottom = true;
+
+  afterUpdate(() => {
+    if (isPrepend) isPrepend = false;
+    if (ref && shouldStickToBottom) {
+      ref.scrollToIndex(items.length - 1, { align: "end" });
+    }
+  });
+
+  onMount(() => {
+    let canceled = false;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const setTimer = () => {
+      timer = setTimeout(() => {
+        if (canceled) return;
+        items = [...items, createItem()];
+        setTimer();
+      }, 5000);
+    };
+    setTimer();
+    return () => {
+      canceled = true;
+      if (timer) {
+        clearTimeout(timer);
+      }
+    };
+  });
+
+  const disabled = $derived(!value.length);
+  const submit = () => {
+    if (disabled) return;
+    shouldStickToBottom = true;
+    items = [...items, createItem({ value, me: true })];
+    value = "";
+  };
+</script>
+
+<div style="width: 90vw; height: 90vh; display: flex; flex-direction: column;">
+  <VList
+    bind:this={ref}
+    style="flex: 1"
+    {items}
+    getKey={(d) => d.id}
+    reverse
+    shift={isPrepend}
+    onscroll={(offset) => {
+      if (!ref) return;
+      shouldStickToBottom =
+        offset - ref.getScrollSize() + ref.getViewportSize() >= -1.5;
+      if (offset < 100) {
+        isPrepend = true;
+        items = [
+          ...Array.from({ length: 100 }, () => createItem()),
+          ...items,
+        ];
+      }
+    }}
+  >
+    {#snippet children(item)}
+      <div
+        style={`
+          border: solid 1px #ccc;
+          background: #fff;
+          margin: 10px;
+          padding: 10px;
+          border-radius: 8px;
+          white-space: pre-wrap;
+          ${item.me ? 'background: lightyellow; margin-left: 80px;' : 'margin-right: 80px;'}
+        `}
+      >
+        {item.value}
+      </div>
+    {/snippet}
+  </VList>
+  <form
+    style="margin: 10px;"
+    onsubmit={(e) => {
+      e.preventDefault();
+      e.stopPropagation();
+      submit();
+    }}
+  >
+    <textarea
+      style="width: 400px;"
+      rows={6}
+      bind:value={value}
+      onkeydown={(e) => {
+        if (e.code === 'Enter' && (e.ctrlKey || e.metaKey)) {
+          submit();
+          e.preventDefault();
+        }
+      }}
+    />
+    <button type="submit" disabled={disabled}>submit</button>
+    <button type="button" onclick={() => { ref.scrollTo(0); }}>jump to top</button>
+  </form>
+</div>

--- a/stories/svelte/advanced/Chat.stories.tsx
+++ b/stories/svelte/advanced/Chat.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from "@storybook/svelte";
+import { VList } from "../../../src/svelte";
+import ChatComponent from "./Chat.stories.svelte";
+
+export default {
+  component: VList,
+} satisfies Meta;
+
+export const Default: StoryObj = {
+  name: "Chat",
+  render: () => ({
+    Component: ChatComponent,
+  }),
+};


### PR DESCRIPTION
## Summary
- support `reverse` in Svelte VList API
- render reversed layout in VList.svelte when enabled
- document `reverse` option for Svelte
- add Chat story for Svelte demonstrating reversed chat view

## Testing
- `npm test`
- `npm run -s check:svelte`
- `npm run -s lint` *(warnings only)*